### PR TITLE
Add File IO interface

### DIFF
--- a/micropolis-cpp.vcxproj
+++ b/micropolis-cpp.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClCompile Include="src\Budget.cpp" />
     <ClCompile Include="src\BudgetWindow.cpp" />
+    <ClCompile Include="src\FileIo.cpp" />
     <ClCompile Include="src\Font.cpp" />
     <ClCompile Include="src\GraphWindow.cpp" />
     <ClCompile Include="src\g_ani.cpp" />
@@ -60,6 +61,7 @@
     <ClInclude Include="src\Budget.h" />
     <ClInclude Include="src\BudgetWindow.h" />
     <ClInclude Include="src\CityProperties.h" />
+    <ClInclude Include="src\FileIo.h" />
     <ClInclude Include="src\Font.h" />
     <ClInclude Include="src\Graph.h" />
     <ClInclude Include="src\GraphWindow.h" />
@@ -204,7 +206,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -213,7 +215,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>sdl2maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sdl2maind.lib;%(AdditionalDependencies);Shlwapi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -222,7 +224,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -236,7 +238,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>sdl2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>sdl2main.lib;%(AdditionalDependencies);Shlwapi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/micropolis-cpp.vcxproj.filters
+++ b/micropolis-cpp.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="src\GraphWindow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\FileIo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\animtab.h">
@@ -249,6 +252,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Graph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FileIo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -1,0 +1,129 @@
+// This file is part of Micropolis-SDL2PP
+// Micropolis-SDL2PP is based on Micropolis
+//
+// Copyright © 2022 Leeor Dicker
+//
+// Portions Copyright © 1989-2007 Electronic Arts Inc.
+//
+// Micropolis-SDL2PP is free software; you can redistribute it and/or modify
+// it under the terms of the GNU GPLv3, with additional terms. See the README
+// file, included in this distribution, for details.
+
+#include "FileIo.h"
+
+#define NOMINMAX
+#include <windows.h>
+#include <ShlObj_core.h>
+#include <Shlwapi.h>
+#undef NOMINMAX
+
+
+#include <locale>
+#include <codecvt>
+#include <sstream>
+#include <stdexcept>
+
+
+namespace
+{
+    COMDLG_FILTERSPEC FileTypeFilter[] =
+    {
+        { L"Micropolis City", L"*.cty"}
+    };
+
+
+    const std::string StringFromWString(const std::wstring& str)
+    {
+        const auto length = WideCharToMultiByte(CP_UTF8, 0, &str.at(0), (int)str.size(), nullptr, 0, nullptr, nullptr);
+
+        if (length <= 0)
+        {
+            throw std::runtime_error("WideCharToMultiByte() failed.");
+        }
+
+        std::string out(length, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &str.at(0), (int)str.size(), &out.at(0), length, nullptr, nullptr);
+        return out;
+    }
+
+};
+
+
+FileIo::FileIo(SDL_Window& window):
+	mWindow(window)
+{
+	SDL_GetWindowWMInfo(&mWindow, &mWmInfo);
+
+    wchar_t* path{ nullptr };
+    if (SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_CREATE, NULL, &path) != S_OK)
+    {
+        throw std::runtime_error("Unable to get user documents path.");
+    }
+
+    std::wstringstream ss;
+    ss << path << L"\\Micropolis";
+    mSavePathW = ss.str();
+    mSavePath = StringFromWString(mSavePathW);
+
+    if (!PathFileExists(mSavePathW.c_str()))
+    {
+        CreateDirectory(mSavePathW.c_str(), nullptr);
+    }
+}
+
+
+void FileIo::saveFile()
+{
+}
+
+
+void FileIo::openFile()
+{
+    // CoCreate the File Open Dialog object.
+    IFileDialog* fileOpenDialog{ nullptr };
+
+    if (!SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&fileOpenDialog))))
+    {
+        throw std::runtime_error("Unable to create file IO dialog");
+    }
+
+    IShellItem* defaultFolder{ nullptr };
+    SHCreateItemFromParsingName(mSavePathW.c_str(), nullptr, IID_PPV_ARGS(&defaultFolder));
+    fileOpenDialog->SetDefaultFolder(defaultFolder);
+    defaultFolder->Release();
+
+    DWORD dwFlags{};
+    fileOpenDialog->GetOptions(&dwFlags);
+
+    fileOpenDialog->SetOptions(dwFlags | FOS_FORCEFILESYSTEM);
+    fileOpenDialog->SetFileTypes(ARRAYSIZE(FileTypeFilter), FileTypeFilter);
+    fileOpenDialog->SetFileTypeIndex(1);
+    fileOpenDialog->SetDefaultExtension(L"cty");
+
+    if (!SUCCEEDED(fileOpenDialog->Show(mWmInfo.info.win.window)))
+    {
+        fileOpenDialog->Release();
+        return;
+    }
+
+    IShellItem* psiResult{ nullptr };
+    if (SUCCEEDED(fileOpenDialog->GetResult(&psiResult)))
+    {
+        PWSTR filePath{ nullptr };
+
+        if (!SUCCEEDED(psiResult->GetDisplayName(SIGDN_FILESYSPATH, &filePath)))
+        {
+            throw std::runtime_error("Unable to get file name");
+        }
+        mFileNameW = filePath;
+        CoTaskMemFree(filePath);
+
+        psiResult->Release();
+    }
+
+    fileOpenDialog->Release();
+
+    std::size_t location = mFileNameW.find_last_of(L"/\\");
+    mFileNameW = mFileNameW.substr(location + 1);
+    mFileName = StringFromWString(mFileNameW);
+}

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -77,11 +77,17 @@ void FileIo::pickSaveFile()
 }
 
 
+/**
+ * There are a few assumptions here regarding the Win32 API's handling of the file
+ * open interface -- creating items, setting parameters and options, etc. are all
+ * assumed to not fail. If they fail this will undoubtedly result in other issues.
+ * 
+ * The checks are not present for the sake of brevity. If it's determined that the
+ * hresult checks are necessary they can be added as needed.
+ */
 void FileIo::pickOpenFile()
 {
-    // CoCreate the File Open Dialog object.
     IFileDialog* fileOpenDialog{ nullptr };
-
     if (!SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&fileOpenDialog))))
     {
         throw std::runtime_error("Unable to create file IO dialog");

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -72,12 +72,12 @@ FileIo::FileIo(SDL_Window& window):
 }
 
 
-void FileIo::saveFile()
+void FileIo::pickSaveFile()
 {
 }
 
 
-void FileIo::openFile()
+void FileIo::pickOpenFile()
 {
     // CoCreate the File Open Dialog object.
     IFileDialog* fileOpenDialog{ nullptr };

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -106,19 +106,19 @@ void FileIo::pickOpenFile()
         return;
     }
 
-    IShellItem* psiResult{ nullptr };
-    if (SUCCEEDED(fileOpenDialog->GetResult(&psiResult)))
+    IShellItem* item{ nullptr };
+    if (SUCCEEDED(fileOpenDialog->GetResult(&item)))
     {
         PWSTR filePath{ nullptr };
 
-        if (!SUCCEEDED(psiResult->GetDisplayName(SIGDN_FILESYSPATH, &filePath)))
+        if (!SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &filePath)))
         {
             throw std::runtime_error("Unable to get file name");
         }
         mFileNameW = filePath;
         CoTaskMemFree(filePath);
 
-        psiResult->Release();
+        item->Release();
     }
 
     fileOpenDialog->Release();

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -87,33 +87,33 @@ void FileIo::pickSaveFile()
  */
 void FileIo::pickOpenFile()
 {
-    IFileDialog* fileOpenDialog{ nullptr };
-    if (!SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&fileOpenDialog))))
+    IFileDialog* fileDialog{ nullptr };
+    if (!SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&fileDialog))))
     {
         throw std::runtime_error("Unable to create file IO dialog");
     }
 
     IShellItem* defaultFolder{ nullptr };
     SHCreateItemFromParsingName(mSavePathW.c_str(), nullptr, IID_PPV_ARGS(&defaultFolder));
-    fileOpenDialog->SetDefaultFolder(defaultFolder);
+    fileDialog->SetDefaultFolder(defaultFolder);
     defaultFolder->Release();
 
     DWORD dwFlags{};
-    fileOpenDialog->GetOptions(&dwFlags);
+    fileDialog->GetOptions(&dwFlags);
 
-    fileOpenDialog->SetOptions(dwFlags | FOS_FORCEFILESYSTEM);
-    fileOpenDialog->SetFileTypes(ARRAYSIZE(FileTypeFilter), FileTypeFilter);
-    fileOpenDialog->SetFileTypeIndex(1);
-    fileOpenDialog->SetDefaultExtension(L"cty");
+    fileDialog->SetOptions(dwFlags | FOS_FORCEFILESYSTEM);
+    fileDialog->SetFileTypes(ARRAYSIZE(FileTypeFilter), FileTypeFilter);
+    fileDialog->SetFileTypeIndex(1);
+    fileDialog->SetDefaultExtension(L"cty");
 
-    if (!SUCCEEDED(fileOpenDialog->Show(mWmInfo.info.win.window)))
+    if (!SUCCEEDED(fileDialog->Show(mWmInfo.info.win.window)))
     {
-        fileOpenDialog->Release();
+        fileDialog->Release();
         return;
     }
 
     IShellItem* item{ nullptr };
-    if (SUCCEEDED(fileOpenDialog->GetResult(&item)))
+    if (SUCCEEDED(fileDialog->GetResult(&item)))
     {
         PWSTR filePath{ nullptr };
 
@@ -127,7 +127,7 @@ void FileIo::pickOpenFile()
         item->Release();
     }
 
-    fileOpenDialog->Release();
+    fileDialog->Release();
 
     std::size_t location = mFileNameW.find_last_of(L"/\\");
     mFileNameW = mFileNameW.substr(location + 1);

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -72,25 +72,35 @@ FileIo::FileIo(SDL_Window& window):
 }
 
 
-void FileIo::pickSaveFile()
+/**
+ * \return Returns true if a file name was selected, false otherwise.
+ */
+bool FileIo::pickSaveFile()
 {
-    showFileDialog(FileOperation::Save);
-    extractFileName();
+    const auto filePicked = showFileDialog(FileOperation::Save);
+    
+    if (filePicked)
+    {
+        extractFileName();
+    }
+
+    return filePicked;
 }
 
 
 /**
- * There are a few assumptions here regarding the Win32 API's handling of the file
- * open interface -- creating items, setting parameters and options, etc. are all
- * assumed to not fail. If they fail this will undoubtedly result in other issues.
- * 
- * The checks are not present for the sake of brevity. If it's determined that the
- * hresult checks are necessary they can be added as needed.
+ * \return Returns true if a file name was selected, false otherwise.
  */
-void FileIo::pickOpenFile()
+bool FileIo::pickOpenFile()
 {
-    showFileDialog(FileOperation::Open);
-    extractFileName();
+    const auto filePicked = showFileDialog(FileOperation::Open);
+
+    if (filePicked)
+    {
+        extractFileName();
+    }
+
+    return filePicked;
 }
 
 
@@ -102,7 +112,17 @@ void FileIo::extractFileName()
 }
 
 
-void FileIo::showFileDialog(FileOperation operation)
+/**
+ * There are a few assumptions here regarding the Win32 API's handling of the file
+ * pick interface -- creating items, setting parameters and options, etc. are all
+ * assumed to not fail. If they fail this will undoubtedly result in other issues.
+ *
+ * The checks are not present for the sake of brevity. If it's determined that the
+ * hresult checks are necessary they can be added as needed.
+ * 
+ * \return Returns true if a file name has been picked. False otherwise.
+ */
+bool FileIo::showFileDialog(FileOperation operation)
 {
     CLSID fileOperation
     {
@@ -136,7 +156,7 @@ void FileIo::showFileDialog(FileOperation operation)
     if (!SUCCEEDED(fileDialog->Show(mWmInfo.info.win.window)))
     {
         fileDialog->Release();
-        return;
+        return false;
     }
 
     IShellItem* item{ nullptr };
@@ -155,4 +175,6 @@ void FileIo::showFileDialog(FileOperation operation)
     }
 
     fileDialog->Release();
+
+    return true;
 }

--- a/src/FileIo.h
+++ b/src/FileIo.h
@@ -26,14 +26,15 @@ public:
 	~FileIo() = default;
 
 	const std::string& savePath() const { return mSavePath; }
+	const std::string& fileName() const { return mFileName; }
 
-	void pickSaveFile();
-	void pickOpenFile();
+	bool pickSaveFile();
+	bool pickOpenFile();
 
 private:
 	enum class FileOperation { Open, Save };
 
-	void showFileDialog(FileOperation);
+	bool showFileDialog(FileOperation);
 	void extractFileName();
 
 	SDL_Window& mWindow;

--- a/src/FileIo.h
+++ b/src/FileIo.h
@@ -31,6 +31,11 @@ public:
 	void pickOpenFile();
 
 private:
+	enum class FileOperation { Open, Save };
+
+	void showFileDialog(FileOperation);
+	void extractFileName();
+
 	SDL_Window& mWindow;
 	SDL_SysWMinfo mWmInfo{};
 

--- a/src/FileIo.h
+++ b/src/FileIo.h
@@ -1,0 +1,42 @@
+// This file is part of Micropolis-SDL2PP
+// Micropolis-SDL2PP is based on Micropolis
+//
+// Copyright © 2022 Leeor Dicker
+//
+// Portions Copyright © 1989-2007 Electronic Arts Inc.
+//
+// Micropolis-SDL2PP is free software; you can redistribute it and/or modify
+// it under the terms of the GNU GPLv3, with additional terms. See the README
+// file, included in this distribution, for details.
+#pragma once
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_syswm.h>
+
+#include <string>
+
+class FileIo
+{
+public:
+	FileIo() = delete;
+	FileIo(const FileIo&) = delete;
+	const FileIo& operator=(const FileIo&) = delete;
+
+	FileIo(SDL_Window& window);
+	~FileIo() = default;
+
+	const std::string& savePath() const { return mSavePath; }
+
+	void saveFile();
+	void openFile();
+
+private:
+	SDL_Window& mWindow;
+	SDL_SysWMinfo mWmInfo{};
+
+	std::string mSavePath;
+	std::wstring mSavePathW;
+
+	std::string mFileName;
+	std::wstring mFileNameW;
+};

--- a/src/FileIo.h
+++ b/src/FileIo.h
@@ -27,8 +27,8 @@ public:
 
 	const std::string& savePath() const { return mSavePath; }
 
-	void saveFile();
-	void openFile();
+	void pickSaveFile();
+	void pickOpenFile();
 
 private:
 	SDL_Window& mWindow;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1014,6 +1014,7 @@ int main(int argc, char* argv[])
         fileIo = new FileIo(*MainWindow);
 
         fileIo->pickOpenFile();
+        fileIo->pickSaveFile();
 
         initViewParamters();
         updateMapDrawParameters();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "GraphWindow.h"
 
 #include "CityProperties.h"
+#include "FileIo.h"
 #include "Font.h"
 #include "Graph.h"
 #include "Map.h"
@@ -122,6 +123,8 @@ namespace
     StringRender* stringRenderer{ nullptr };
 
     CityProperties cityProperties;
+
+    FileIo* fileIo{ nullptr };
 
     unsigned int speedModifier()
     {
@@ -977,6 +980,7 @@ void cleanUp()
     delete budgetWindow;
     delete graphWindow;
     delete stringRenderer;
+    delete fileIo;
 
     SDL_DestroyTexture(BigTileset.texture);
     SDL_DestroyTexture(RCI_Indicator.texture);
@@ -1006,6 +1010,10 @@ int main(int argc, char* argv[])
 
         MainFont = new Font("res/raleway-medium.ttf", 12);
         MainBigFont = new Font("res/raleway-medium.ttf", 14);
+
+        fileIo = new FileIo(*MainWindow);
+
+        fileIo->openFile();
 
         initViewParamters();
         updateMapDrawParameters();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1013,7 +1013,7 @@ int main(int argc, char* argv[])
 
         fileIo = new FileIo(*MainWindow);
 
-        fileIo->openFile();
+        fileIo->pickOpenFile();
 
         initViewParamters();
         updateMapDrawParameters();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1013,9 +1013,6 @@ int main(int argc, char* argv[])
 
         fileIo = new FileIo(*MainWindow);
 
-        fileIo->pickOpenFile();
-        fileIo->pickSaveFile();
-
         initViewParamters();
         updateMapDrawParameters();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -582,7 +582,6 @@ void handleMouseEvent(SDL_Event& event)
             {
                 ToolDown(TilePointedAt.x, TilePointedAt.y, budget);
             }
-
         }
         break;
 


### PR DESCRIPTION
Adds native file dialog interface for opening/closing cities. Doesn't actually load or save but allows for deciding where they go and where they come from.

NOTE: This is entirely in Win32 API -- it is not cross platform. Other platforms can be added into the code using conditional compiling and implementing the interface natively. The interface itself should work without much (or any) modification.