### PR TITLE
Fix deleter crash

### DIFF
--- a/src/BudgetWindow.cpp
+++ b/src/BudgetWindow.cpp
@@ -160,10 +160,6 @@ BudgetWindow::BudgetWindow(SDL_Renderer* renderer, const StringRender& stringRen
 }
 
 
-BudgetWindow::~BudgetWindow()
-{}
-
-
 void BudgetWindow::reset()
 {
 	mAccepted = false;

--- a/src/BudgetWindow.h
+++ b/src/BudgetWindow.h
@@ -48,7 +48,6 @@ public:
 	const BudgetWindow& operator=(const BudgetWindow&) = delete;
 
 	BudgetWindow(SDL_Renderer* renderer, const StringRender& stringRenderer, Budget& budget);
-	~BudgetWindow() override;
 
 	void reset();
 
@@ -71,7 +70,7 @@ private:
 	SDL_Renderer* mRenderer{ nullptr };
 	const StringRender& mStringRenderer;
 
-	std::unique_ptr<Font> mFont{ nullptr };
+	std::unique_ptr<Font> mFont;
 
 	Texture mTexture{};
 

--- a/src/EvaluationWindow.h
+++ b/src/EvaluationWindow.h
@@ -44,9 +44,9 @@ private:
     void drawScorePanel();
     
 private:
-    Font* mFont{ nullptr };
-    Font* mFontBold{ nullptr };
-    Font* mFontSemiBold{ nullptr };
+    std::unique_ptr<Font> mFont;
+    std::unique_ptr<Font> mFontBold;
+    std::unique_ptr<Font> mFontSemiBold;
 
     const int mLineSpacing{ 0 };
     const int mTitleSpacing{ 0 };

--- a/src/QueryWindow.h
+++ b/src/QueryWindow.h
@@ -41,9 +41,9 @@ private:
     void onMouseDown(const Point<int>&) override;
 
 private:
-    Font* mFont{ nullptr };
-    Font* mFontBold{ nullptr };
-    Font* mFontBoldItalic{ nullptr };
+    std::unique_ptr<Font> mFont;
+    std::unique_ptr<Font> mFontBold;
+    std::unique_ptr<Font> mFontBoldItalic;
 
     Texture mTexture;
     Texture mTextTexture;


### PR DESCRIPTION
Been getting a crash on close that I think is related to the `BudgetWindow` d'tor override. Not sure why that would cause anything but each time I get an access violation it's always in `Font::~Font()` and always from `BudgetWindow::~BudgetWindow()`.

I opted to convert all raw Font pointers to `std::unique_ptr`'s to ensure RAII and proper freeing of memory without having to deal with it manually.

Further testing will let me know if this PR does the trick.